### PR TITLE
Adding support for Laravel Session storage backend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=5.3.0",
         "illuminate/session": "~4",
         "illuminate/support": "~4",
-        "lusitanian/oauth": "~0.2"
+        "lusitanian/oauth": "~0.3"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
+        "illuminate/session": "~4",
         "illuminate/support": "~4",
         "lusitanian/oauth": "~0.2"
     },

--- a/src/Codesleeve/Social/Session.php
+++ b/src/Codesleeve/Social/Session.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Codesleeve\Social;
+
+use OAuth\Common\Token\TokenInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
+use OAuth\Common\Storage\Exception\TokenNotFoundException;
+use OAuth\Common\Storage\Exception\AuthorizationStateNotFoundException;
+use Illuminate\Session\Store;
+
+/**
+ * Stores a token in a PHP session.
+ */
+class Session implements TokenStorageInterface
+{
+    /**
+     * @var object|Store
+     */
+    protected $session;
+
+    /**
+     * @var string
+     */
+    protected $sessionVariableName;
+
+    /**
+     * @var string
+     */
+    protected $stateVariableName;
+
+    /**
+     * @param string $sessionVariableName
+     * @param string $stateVariableName
+     */
+    public function __construct(
+        Store $session,
+        $sessionVariableName = 'lusitanian_oauth_token',
+        $stateVariableName = 'lusitanian_oauth_state'
+    ) {
+        $this->session = $session;
+        $this->sessionVariableName = $sessionVariableName;
+        $this->stateVariableName = $stateVariableName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieveAccessToken($service)
+    {
+        if ($this->hasAccessToken($service)) {
+            return unserialize($this->session->get("$this->sessionVariableName.$service"));
+        }
+
+        throw new TokenNotFoundException('Token not found in session, are you sure you stored it?');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function storeAccessToken($service, TokenInterface $token)
+    {
+        $this->session->set("$this->sessionVariableName.$service", serialize($token));
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAccessToken($service)
+    {
+        return $this->session->has("$this->sessionVariableName.$service");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearToken($service)
+    {
+        $this->session->forget("$this->sessionVariableName.$service");
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearAllTokens()
+    {
+        $this->session->forget($this->sessionVariableName);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function storeAuthorizationState($service, $state)
+    {
+        $this->session->set("$this->stateVariableName.$service", $state);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAuthorizationState($service)
+    {
+        return $this->session->has("$this->stateVariableName.$service");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieveAuthorizationState($service)
+    {
+        if ($this->hasAuthorizationState($service)) {
+            return $this->session->get("$this->stateVariableName.$service");
+        }
+
+        throw new AuthorizationStateNotFoundException('State not found in session, are you sure you stored it?');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearAuthorizationState($service)
+    {
+        $this->session->forget("$this->stateVariableName.$service");
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearAllAuthorizationStates()
+    {
+        $this->session->forget($this->stateVariableName);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * @return Session
+     */
+    public function getSession()
+    {
+        return $this->session;
+    }
+}

--- a/src/Codesleeve/Social/SocialRepository.php
+++ b/src/Codesleeve/Social/SocialRepository.php
@@ -3,7 +3,6 @@
 namespace Codesleeve\Social;
 
 use OAuth\OAuth2\Service\Facebook;
-use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
 use OAuth\ServiceFactory;
 
@@ -13,10 +12,11 @@ class SocialRepository extends ServiceFactory {
 	 * [__construct description]
 	 * @param [type] $config [description]
 	 */
-	public function __construct($config, $url)
+	public function __construct($config, $url, $session)
 	{
 		$this->config = $config;
 		$this->url = $url;
+		$this->session = $session;
 		$this->setDecoder();
 	}
 
@@ -177,7 +177,7 @@ class SocialRepository extends ServiceFactory {
 		$scopes = $this->config->get("social::$name.scopes");
 
 		$credentials = new Credentials($key, $secret, $url);
-		$storage = new Session;
+		$storage = new Session($this->session->driver());
 
 		$factory = new ServiceFactory;
 		return $factory->createService($name, $credentials, $storage, $scopes);

--- a/src/Codesleeve/Social/SocialServiceProvider.php
+++ b/src/Codesleeve/Social/SocialServiceProvider.php
@@ -23,7 +23,7 @@ class SocialServiceProvider extends ServiceProvider {
 		include __DIR__.'/../../routes.php';
 	
 		$this->app['social'] = $this->app->share(function($app) {
-            return new SocialRepository($app['config'], $app['url']);
+            return new SocialRepository($app['config'], $app['url'], $app['session']);
         });
 	}
 

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Codesleeve\Social\Session;
+use OAuth\OAuth2\Token\StdOAuth2Token;
+use Illuminate\Session\Store;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
+
+class SessionTest extends \PHPUnit_Framework_TestCase
+{
+    protected $session;
+
+    protected $storage;
+
+    public function setUp()
+    {
+        // set it
+        $this->session = new Store('name', new NullSessionHandler, 1);
+        $this->storage = new Session($this->session);
+    }
+
+    public function tearDown()
+    {
+        // delete
+        $this->storage->getSession()->clear();
+        unset($this->storage);
+    }
+
+    /**
+     * Check that the token survives the constructor
+     */
+    public function testStorageSurvivesConstructor()
+    {
+        $service = 'Facebook';
+        $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+
+        // act
+        $this->storage->storeAccessToken($service, $token);
+        $this->storage = null;
+        $this->storage = new Session($this->session);
+
+        // assert
+        $extraParams = $this->storage->retrieveAccessToken($service)->getExtraParams();
+        $this->assertEquals('param', $extraParams['extra']);
+        $this->assertEquals($token, $this->storage->retrieveAccessToken($service));
+    }
+
+    /**
+     * Check that the token gets properly stored.
+     */
+    public function testStorage()
+    {
+        // arrange
+        $service_1 = 'Facebook';
+        $service_2 = 'Foursquare';
+
+        $token_1 = new StdOAuth2Token('access_1', 'refresh_1', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+        $token_2 = new StdOAuth2Token('access_2', 'refresh_2', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+
+        // act
+        $this->storage->storeAccessToken($service_1, $token_1);
+        $this->storage->storeAccessToken($service_2, $token_2);
+
+        // assert
+        $extraParams = $this->storage->retrieveAccessToken($service_1)->getExtraParams();
+        $this->assertEquals('param', $extraParams['extra']);
+        $this->assertEquals($token_1, $this->storage->retrieveAccessToken($service_1));
+        $this->assertEquals($token_2, $this->storage->retrieveAccessToken($service_2));
+    }
+
+    /**
+     * Test hasAccessToken.
+     */
+    public function testHasAccessToken()
+    {
+        // arrange
+        $service = 'Facebook';
+        $this->storage->clearToken($service);
+
+        // act
+        // assert
+        $this->assertFalse($this->storage->hasAccessToken($service));
+    }
+
+    /**
+     * Check that the token gets properly deleted.
+     */
+    public function testStorageClears()
+    {
+        // arrange
+        $service = 'Facebook';
+        $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+
+        // act
+        $this->storage->storeAccessToken($service, $token);
+        $this->storage->clearToken($service);
+
+        // assert
+        $this->setExpectedException('OAuth\Common\Storage\Exception\TokenNotFoundException');
+        $this->storage->retrieveAccessToken($service);
+    }
+}

--- a/tests/SocialRepositoryTest.php
+++ b/tests/SocialRepositoryTest.php
@@ -28,7 +28,7 @@ class SocialRepositoryTest extends PHPUnit_Framework_TestCase
      * @param  [type] $url    [description]
      * @return [type]         [description]
      */
-    public function newSocial($config = null, $url = null)
+    public function newSocial($config = null, $url = null, $session = null)
     {
         if (!$config) {
             $config = $this->getMock('Config');            
@@ -38,7 +38,11 @@ class SocialRepositoryTest extends PHPUnit_Framework_TestCase
             $url = $this->getMock('Url');            
         }
 
-        $social = new SocialRepository($config, $url);
+        if (!$session) {
+            $session = $this->getMock('Session');            
+        }
+
+        $social = new SocialRepository($config, $url, $session);
 
         return $social;
     }


### PR DESCRIPTION
I experienced issues in Laravel 4.1 with PHPs native session data (used by PHPoAuthLib) being reset on each page load. These updates allow us to use the Laravel session store inside PHPoAuthLib.
